### PR TITLE
Update speedrank to support Odin and 6* magicite

### DIFF
--- a/commands/misc/speedrank.js
+++ b/commands/misc/speedrank.js
@@ -28,7 +28,7 @@ module.exports = class ReplyCommand extends Command {
         {
           key: 'category',
           prompt: 'Enter the name of the category you want to look up.' +
-          ' (Can be "5star", "4star", "3star", or "Torment" ' +
+          ' (Can be "6star", "odin", "5star", "4star", "3star", or "Torment" ' +
           ' on the chart. The default is "4star")',
           type: 'string',
           default: '4star',

--- a/utilities/speedrank-utils.js
+++ b/utilities/speedrank-utils.js
@@ -178,6 +178,12 @@ function getSheet(category, secondaryCategory) {
   else if (['5','5star','5-star','5 star'].includes(category.toLowerCase())){
     category = `GL 5* ${version} rankings`;
   }
+  else if (['6','6star','6-star','6 star'].includes(category.toLowerCase())){
+    category = `GL 6* ${version}`;
+  }
+  else if (['odin','darkodin','dark-odin','dark odin'].includes(category.toLowerCase())){
+    category = `Odin ${version}`;
+  }
   else if (['torment', 'tor', 'neotorment', 'neo'].includes(category.toLowerCase())){
     category = 'Torment';
   }


### PR DESCRIPTION
Added a few extra cases to cover newer sheets for Dark Odin magicite and 6* magicite.
Updated prompt with the new cases.